### PR TITLE
Change positioning on target-label-wrapper

### DIFF
--- a/html/css/style.css
+++ b/html/css/style.css
@@ -17,7 +17,7 @@ body {
     align-content: center;
     justify-content: center;
     flex-direction: row;
-    left: 91.5vh;
+    left: 51.25%;
     width: fit-content;
     height: 100%;
     top: 49.25%;


### PR DESCRIPTION
Users with high resolutions are not seeing target labels in the correct location. They are far away from the screen. 

Fixes #42 