### PR TITLE
Fix: Required item update

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -30,7 +30,7 @@ if not Config.Standalone then
 	end)
 
 	-- This will make sure all the PlayerData stays updated
-	RegisterNetEvent('QBCore:Client:SetPlayerData', function(val)
+	RegisterNetEvent('QBCore:Player:SetPlayerData', function(val)
 		PlayerData = val
 	end)
 


### PR DESCRIPTION
I've been having this issue for a good month now. Looked through the script, noticed this event doesn't match the event in QBCore. Updating this to match actually updates the PlayerData so it recognizes when an item is in your inventory or broken, dropped, etc. Tested in a solo dev environment; is also the same method used in nui_doorlock.

Fixes #56 and maybe others