### PR TITLE
fix spawning double ped issue present in some resources

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -899,11 +899,9 @@ function Functions.SpawnPed(data)
 			end
 			v.currentpednumber = spawnedped
 
-			local nextnumber = #Config.Peds + 1
-			if nextnumber <= 0 then
-				nextnumber = 1
-			end
-
+			local nextnumber = #Config.Peds
+			nextnumber = nextnumber <= 0 and 1 or nextnumber + 1
+			
 			Config.Peds[nextnumber] = v
 		end
 	else


### PR DESCRIPTION
In some third-party resources peds for jobs would potentially spawn 2 instead of one, on top of one another. This PR fixes that.