### PR TITLE
Option sorting by specified position, or dynamically

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -952,7 +952,7 @@ exports("AllowTargeting", function(bool) AllowTarget = bool end)
 
 -- NUI Callbacks
 
-RegisterNUICallback('selectTarget', function(option)
+RegisterNUICallback('selectTarget', function(option, cb)
     SetNuiFocus(false, false)
     SetNuiFocusKeepInput(false)
 	Wait(100)
@@ -979,7 +979,7 @@ RegisterNUICallback('selectTarget', function(option)
 					end
 				else
 					print("No trigger setup")
-				end				
+				end
 			end
 		end)
 	end


### PR DESCRIPTION
Developers can now use a "position" key in the generation of any options for a target to ensure that the options will be placed in that order. If a position is not provided, the next available index will be chosen dynamically.