### PR TITLE
Remove entity from SetEntityDrawOutlineColor

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -120,7 +120,7 @@ exports('DisableTarget', DisableTarget)
 local function DrawOutlineEntity(entity, bool)
 	if not Config.EnableOutline or IsEntityAPed(entity) then return end
 	SetEntityDrawOutline(entity, bool)
-	SetEntityDrawOutlineColor(entity, Config.OutlineColor[1], Config.OutlineColor[2], Config.OutlineColor[3])
+	SetEntityDrawOutlineColor(Config.OutlineColor[1], Config.OutlineColor[2], Config.OutlineColor[3])
 end
 
 exports('DrawOutlineEntity', DrawOutlineEntity)


### PR DESCRIPTION
Removed `entity` from this as it only accepts RGBA (entity is set in the line before). Alpha does not appear to have any effect. Outline color works as designed with this change.